### PR TITLE
changed function() to callable() in type specification of erlcron:at/2 and erlcron:once/2

### DIFF
--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -76,14 +76,14 @@ cron(Job) ->
 %% @doc
 %%  Convienience method to specify a job run to run on a daily basis
 %%  at a specific time.
--spec at/2 :: (cron_time() | seconds(), function()) -> job_ref().
+-spec at/2 :: (cron_time() | seconds(), callable()) -> job_ref().
 at(When, Fun) ->
     Job = {{daily, When}, Fun},
     cron(Job).
 
 %% @doc
 %%   Run the specified job once after the amount of time specifed.
--spec once/2 :: (cron_time() | seconds(), function()) ->  job_ref().
+-spec once/2 :: (cron_time() | seconds(), callable()) ->  job_ref().
 once(When, Fun) ->
     Job = {{once, When}, Fun},
     cron(Job).


### PR DESCRIPTION
The type specifications of erlcron:at/2 and erlcron:once/2 specify the second argument should be a function(), however they truly accept the type callable() (which is a superset of function()). Because of this our Dialyzer reports throw a lot of error. Fixed it in this pull request.
