### PR TITLE
fix typespec

### DIFF
--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -41,7 +41,7 @@
 -type period()     :: cron_time() | {every, duration(), constraint()}.
 -type dom()        :: integer().
 -type dow()        :: mon | tue | wed | thu | fri | sat | sun.
--type callable()   :: mfa() | function().
+-type callable()   :: {M :: module(), F :: atom(), A :: [term()]} | function().
 -type run_when()   :: {once, cron_time()}
                     | {once, seconds()}
                     | {daily, period()}


### PR DESCRIPTION
Fixes incorrect typespec. `mfa()` stands for module/function/arity (see [here](http://erlang.org/doc/reference_manual/typespec.html#id76497), in the table of built-in types). However, erlcron takes something similar to supervisor's `mfargs()`.