### PR TITLE
Return secs when calling a valid spec in erlcron:validate/1.

### DIFF
--- a/src/ecrn_agent.erl
+++ b/src/ecrn_agent.erl
@@ -68,15 +68,14 @@ recalculate(Pid) ->
 
 %% @doc
 %%  Validate that a run_when spec specified is correct.
--spec validate(erlcron:run_when()) -> valid | invalid.
+-spec validate(erlcron:run_when()) -> {valid, erlcron:seconds()} | invalid.
 validate(Spec) ->
     State = #state{job=undefined,
                    alarm_ref=undefined},
     {DateTime, Actual} = ecrn_control:datetime(),
     NewState = set_internal_time(State, DateTime, Actual),
     try
-        until_next_time(NewState, {Spec, undefined}),
-        valid
+        {valid, until_next_time(NewState, {Spec, undefined})}
     catch
         _Error:_Reason ->
             invalid

--- a/src/ecrn_test.erl
+++ b/src/ecrn_test.erl
@@ -147,15 +147,15 @@ cron_test(_) ->
                      end).
 
 validation_test(_) ->
-    ?assertMatch(valid, ecrn_agent:validate({once, {3, 30, pm}})),
-    ?assertMatch(valid, ecrn_agent:validate({once, 3600})),
-    ?assertMatch(valid, ecrn_agent:validate({daily, {every, {23, sec},
+    ?assertMatch({valid, _}, ecrn_agent:validate({once, {3, 30, pm}})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({once, 3600})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({daily, {every, {23, sec},
                                                      {between, {3, pm}, {3, 30, pm}}}})),
-    ?assertMatch(valid, ecrn_agent:validate({daily, {3, 30, pm}})),
-    ?assertMatch(valid, ecrn_agent:validate({weekly, thu, {2, am}})),
-    ?assertMatch(valid, ecrn_agent:validate({weekly, wed, {2, am}})),
-    ?assertMatch(valid, ecrn_agent:validate({monthly, 1, {2, am}})),
-    ?assertMatch(valid, ecrn_agent:validate({monthly, 4, {2, am}})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({daily, {3, 30, pm}})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({weekly, thu, {2, am}})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({weekly, wed, {2, am}})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({monthly, 1, {2, am}})),
+    ?assertMatch({valid, _}, ecrn_agent:validate({monthly, 4, {2, am}})),
     ?assertMatch(invalid, ecrn_agent:validate({daily, {55, 22, am}})),
     ?assertMatch(invalid, ecrn_agent:validate({monthly, 65, {55, am}})).
 

--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -60,7 +60,7 @@
 
 %% @doc
 %%  Check that the spec specified is valid or invalid
--spec validate(run_when()) -> valid | invalid.
+-spec validate(run_when()) -> {valid, erlcron:seconds()} | invalid.
 validate(Spec) ->
     ecrn_agent:validate(Spec).
 


### PR DESCRIPTION
For valid specs we need the seconds until next time.

Also if possible can you tag a release ? 

Thanks!