### PR TITLE
Add support for 0 args jobs

### DIFF
--- a/src/ecrn_agent.erl
+++ b/src/ecrn_agent.erl
@@ -154,11 +154,14 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 
 do_job_run(State, {_, Job})
-  when is_record(State, state), is_function(Job) ->
+  when is_record(State, state), is_function(Job, 2) ->
     RunFun = fun() ->
                      Job(State#state.alarm_ref, current_date(State))
              end,
     proc_lib:spawn(RunFun);
+do_job_run(State, {_, Job})
+  when is_record(State, state), is_function(Job, 0) ->
+    proc_lib:spawn(Job);
 do_job_run(State, {_, {M, F, A}})
   when is_record(State, state) ->
     proc_lib:spawn(M, F, A).

--- a/src/ecrn_test.erl
+++ b/src/ecrn_test.erl
@@ -22,7 +22,8 @@ cron_test_() ->
              fun cancel_alarm_test/1,
              fun big_time_jump_test/1,
              fun cron_test/1,
-             fun validation_test/1]}}.
+             fun validation_test/1,
+             fun job_arity_test/1]}}.
 
 set_alarm_test(_) ->
     EpochDay = {2000,1,1},
@@ -158,6 +159,21 @@ validation_test(_) ->
     ?assertMatch(valid, ecrn_agent:validate({monthly, 4, {2, am}})),
     ?assertMatch(invalid, ecrn_agent:validate({daily, {55, 22, am}})),
     ?assertMatch(invalid, ecrn_agent:validate({monthly, 65, {55, am}})).
+
+job_arity_test(_) ->
+  Self = self(),
+  erlcron:once(1, fun(_, _) -> Self ! ack end),
+  ?assertMatch(ok, receive
+                         ack -> ok
+                     after
+                         2000 -> timeout
+                     end),
+  erlcron:once(1, fun() -> Self ! ack end),
+  ?assertMatch(ok, receive
+                         ack -> ok
+                     after
+                         2000 -> timeout
+                     end).
 
 %%%===================================================================
 %%% Internal Functions


### PR DESCRIPTION
The idea behind this is in docs we use 0-args funs, but also it makes things more convenient without many complications.