### PR TITLE
Patch to allow compilation for OTP21

### DIFF
--- a/src/ecrn_agent.erl
+++ b/src/ecrn_agent.erl
@@ -194,7 +194,6 @@ normalize_seconds(State, Seconds) ->
         Value when Value >= 0 ->
             Value;
         _ ->
-            erlang:display(erlang:get_stacktrace()),
             throw(invalid_once_exception)
     end.
 


### PR DESCRIPTION
Remove `Erlang:get_stacktrace/0` call to allow compilation with OTP21