### PR TITLE
Add job options and fix a failing test case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23, 24, 25]
+        otp: [24, 25]
       fail-fast: false
     container:
       image: erlang:${{ matrix.otp }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ deps/*
 _build
 rebar3
 TEST*.xml
+.deps_plt
+.eunit/
+.rebar/

--- a/README.md
+++ b/README.md
@@ -153,12 +153,20 @@ The app.config file can be as follow:
         {crontab, [
             {{once, {3, 30, pm}}, {io, fwrite, ["Hello, world!~n"]}},
 
-            {{once, {12, 23, 32}}, {io, fwrite, ["Hello, world!~n"]}},
+            %% A job may be specified to be run only if the current host
+            %% is in the list of given hostnames.  If default crontab
+            %% options are provided in the `defaults` setting,
+            %% the job-specific options will override corresponding
+            %% default options.
+            {{once, {12, 23, 32}}, {io, fwrite, ["Hello, world!~n"]}, #{hostnames => ["somehost"]},
 
             {{daily, {every, {23, sec}, {between, {3, pm}, {3, 30, pm}}}},
              {io, fwrite, ["Hello, world!~n"]}}
+        ]},
 
-        ]}
+        %% Instead of specifying individual options for each job, you can
+        %% define default options here.
+        {defaults, #{hostnames => ["myhost"]}}
     ]}
 ].
 ```

--- a/README.md
+++ b/README.md
@@ -157,8 +157,10 @@ The app.config file can be as follow:
             %% is in the list of given hostnames.  If default crontab
             %% options are provided in the `defaults` setting,
             %% the job-specific options will override corresponding
-            %% default options.
-            {{once, {12, 23, 32}}, {io, fwrite, ["Hello, world!~n"]}, #{hostnames => ["somehost"]},
+            %% default options.  See erlcron:job_opts() for available
+            %% options.
+            {{once, {12, 23, 32}}, {io, fwrite, ["Hello, world!~n"]},
+                #{hostnames => ["somehost"]},
 
             {{daily, {every, {23, sec}, {between, {3, pm}, {3, 30, pm}}}},
              {io, fwrite, ["Hello, world!~n"]}}
@@ -166,7 +168,17 @@ The app.config file can be as follow:
 
         %% Instead of specifying individual options for each job, you can
         %% define default options here.
-        {defaults, #{hostnames => ["myhost"]}}
+        {defaults, #{
+            %% Limit jobs to run only on the given list of hosts
+            hostnames    => ["myhost"],
+
+            %% Function `fun((Ref) -> ok)` to call before a job is started
+            on_job_start => {some_module, function},
+
+            %% Function `fun((Ref, Status :: {ok, Result}|{error, {Reason, StackTrace}}) -> ok)`
+            %% to call after a job has ended
+            on_job_end   => {some_module, function}
+        }}
     ]}
 ].
 ```
@@ -175,3 +187,9 @@ So, when the app will be started, all configurations will be loaded.
 
 Note that the limitation is that in the config file is impossible load an
 anonymous function (or lambda function) so, you only can use {M,F,A} format.
+
+If an `on_job_start` or `on_job_end` functions are provided for any job or as
+default settings, it's the responsibility of a developer to make sure that
+those functions handle exceptions, since the failure in those functions will
+cause the supervisor to restart the job up until the supervisor reaches its
+maximum restart intensity.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ The app.config file can be as follow:
             %% Limit jobs to run only on the given list of hosts
             hostnames    => ["myhost"],
 
-            %% Function `fun((Ref) -> ok)` to call before a job is started
+            %% Function `fun((Ref) -> ignore | any())` to call before a job is started.
+            %% If the function returns `ignore`, the job will not be executed, and the
+            %% `on_job_end` callback will not be executed.
             on_job_start => {some_module, function},
 
             %% Function `fun((Ref, Status :: {ok, Result}|{error, {Reason, StackTrace}}) -> ok)`

--- a/src/ecrn_agent.erl
+++ b/src/ecrn_agent.erl
@@ -9,7 +9,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/2,
+-export([start_link/3,
          cancel/1,
          next_run/1,
          get_datetime/1,
@@ -28,7 +28,8 @@
 -include("internal.hrl").
 
 -record(state, {job,
-                alarm_ref,
+                opts,
+                job_ref,
                 ref_epoch,
                 epoch_at_ref,
                 fast_forward=false,
@@ -68,14 +69,15 @@
 
 %% @doc
 %% Starts the server with the appropriate job and the appropriate ref
--spec start_link(erlcron:job_ref(), erlcron:job()) ->
+-spec start_link(erlcron:job_ref(), erlcron:job(), erlcron:job_opts()) ->
                              ignore | {error, Reason::term()} | {ok, pid()}.
-start_link(JobRef, {When, _Task} = Job) when is_reference(JobRef) ->
+start_link(JobRef, {When, _Task} = Job, JobOpts) when (is_reference(JobRef) orelse is_binary(JobRef))
+                                                    , is_map(JobOpts) ->
     {Sched, DateTime, ActualMsec} = normalize_when(When),
-    gen_server:start_link(?MODULE, [JobRef, Job, Sched, DateTime, ActualMsec], []);
-start_link(JobRef, {When, _Task} = Job) when is_atom(JobRef) ->
+    gen_server:start_link(?MODULE, [JobRef, Job, Sched, DateTime, ActualMsec, JobOpts], []);
+start_link(JobRef, {When, _Task} = Job, JobOpts) when is_atom(JobRef), is_map(JobOpts) ->
     {Sched, DateTime, ActualMsec} = normalize_when(When),
-    gen_server:start_link({local, JobRef}, ?MODULE, [JobRef, Job, Sched, DateTime, ActualMsec], []).
+    gen_server:start_link({local, JobRef}, ?MODULE, [JobRef, Job, Sched, DateTime, ActualMsec, JobOpts], []).
 
 -spec get_datetime(pid()) -> calendar:datetime().
 get_datetime(Pid) ->
@@ -119,7 +121,7 @@ next_run(Pid) ->
 %%  Validate that a run_when spec specified is correct.
 -spec validate(erlcron:run_when()) -> ok | {error, term()}.
 validate(Spec) ->
-    State = #state{job=undefined, alarm_ref=undefined},
+    State = #state{job=undefined, job_ref=undefined},
     {DateTime, ActualMsec} = ecrn_control:ref_datetime(universal),
     NewState = set_internal_time(State, DateTime, ActualMsec),
     try
@@ -136,9 +138,9 @@ validate(Spec) ->
 %%% gen_server callbacks
 %%%===================================================================
 %% @private
-init([JobRef, {When, Task}, Sched, DateTime, ActualMsec]) ->
+init([JobRef, {When, Task}, Sched, DateTime, ActualMsec, JobOpts]) ->
     try
-        State = set_internal_time(#state{alarm_ref=JobRef, job={Sched, Task},
+        State = set_internal_time(#state{job_ref=JobRef, job={Sched, Task}, opts=JobOpts,
                                          last_run=0, next_run=0, orig_when=When},
                                   DateTime, ActualMsec),
         case until_next_milliseconds(State) of
@@ -176,7 +178,7 @@ handle_call({set_datetime, DateTime, CurrEpochMsec}, _From, State) ->
         end
     catch ?EXCEPTION(_, E, ST) ->
         ?LOG_ERROR([{error, "Error setting timeout for job"},
-                    {job_ref, State#state.alarm_ref},
+                    {job_ref, State#state.job_ref},
                     {run_when, element(1, State#state.orig_when)},
                     {reason, E},
                     {stack,  ?GET_STACK(ST)}]),
@@ -232,8 +234,16 @@ process_timeout(#state{last_time=LastTime, next_run=NextRun, last_run=LastRun}=S
         end,
     reply_and_wait(Reply, State).
 
-do_job_run(#state{alarm_ref=Ref, next_run=Time, job={When, Job}} = S) ->
-    execute(Job, Ref, Time),
+do_job_run(#state{job_ref=Ref, next_run=Time, job={When, Job}, opts=Opts} = S) ->
+    case Opts of
+        #{on_job_start := {M,F}} ->
+            M:F(Ref);
+        #{on_job_start := F} when is_function(F, 1) ->
+            F(Ref);
+        _ ->
+            ok
+    end,
+    execute(Job, Ref, Time, maps:get(on_job_end, Opts, undefined)),
     case When of
         {once, _} ->
             stop;
@@ -242,12 +252,33 @@ do_job_run(#state{alarm_ref=Ref, next_run=Time, job={When, Job}} = S) ->
             noreply
     end.
 
-execute(Job, Ref, Time) when is_function(Job, 2) ->
-    proc_lib:spawn(fun() -> Job(Ref, Time) end);
-execute(Job, _, _) when is_function(Job, 0) ->
-    proc_lib:spawn(Job);
-execute({M, F, A}, _, _) when is_atom(M), is_atom(F), is_list(A) ->
-    proc_lib:spawn(M, F, A).
+execute(Job, Ref, Time, OnEnd) when is_function(Job, 2) ->
+    safe_spawn(Ref, fun() -> Job(Ref, Time) end, OnEnd);
+execute(Job, Ref, _, OnEnd) when is_function(Job, 0) ->
+    safe_spawn(Ref, Job, OnEnd);
+execute({M, F}, Ref, Time, OnEnd) when is_atom(M), is_atom(F) ->
+    %% The exported function is checked for arity 0 or 2 when the job is added
+    case erlang:function_exported(M, F, 2) of
+        true  -> safe_spawn(Ref, fun() -> M:F(Ref, Time) end, OnEnd);
+        false -> safe_spawn(Ref, fun() -> M:F()          end, OnEnd)
+    end;
+execute({M, F, A}, Ref, _Time, OnEnd) when is_atom(M), is_atom(F), is_list(A) ->
+    safe_spawn(Ref, fun() -> apply(M, F, A) end, OnEnd).
+
+safe_spawn(Ref, Fun, _OnEnd = {M,F}) when is_atom(M), is_atom(F) ->
+    safe_spawn(Ref, Fun, fun(JobRef, Res) -> M:F(JobRef, Res) end);
+
+safe_spawn(Ref, Fun, OnEnd) when is_function(OnEnd, 2) ->
+    proc_lib:spawn(fun() ->
+      try
+          OnEnd(Ref, {ok, Fun()})
+      catch _:Reason:Stack ->
+          OnEnd(Ref, {error, {Reason, Stack}})
+      end
+    end);
+
+safe_spawn(_Ref, Fun, undefined) ->
+    proc_lib:spawn(Fun).
 
 reply_and_wait(stop, State) ->
     {stop, normal, State};
@@ -650,7 +681,7 @@ fast_forward(#state{ref_epoch=OldRefEpoch, next_run=NextRun}=S, NewRefEpoch, New
                 Msec =< 0 andalso
                     ?LOG_WARNING([{info, "One-time job executed immediately due to negative time shift"},
                                 {time_shift_secs, to_seconds(Msec)},
-                                {job_ref,  State2#state.alarm_ref},
+                                {job_ref,  State2#state.job_ref},
                                 {job_when, State2#state.orig_when}]),
                 false;
             _ ->

--- a/src/ecrn_app.erl
+++ b/src/ecrn_app.erl
@@ -51,10 +51,13 @@ stop(_State) ->
     ok.
 
 setup() ->
-    case application:get_env(erlcron, crontab) of 
+    case application:get_env(erlcron, crontab) of
         {ok, Crontab} ->
+            Def = application:get_env(erlcron, defaults, #{}),
+            is_map(Def) orelse
+              erlang:error("erlcron/defaults config must be a map!"),
             lists:foreach(fun(CronJob) ->
-                erlcron:cron(CronJob) 
+                erlcron:cron(CronJob, Def)
             end, Crontab);
         undefined ->
             ok

--- a/src/ecrn_app.erl
+++ b/src/ecrn_app.erl
@@ -57,7 +57,16 @@ setup() ->
             is_map(Def) orelse
               erlang:error("erlcron/defaults config must be a map!"),
             lists:foreach(fun(CronJob) ->
-                erlcron:cron(CronJob, Def)
+                case erlcron:cron(CronJob, Def) of
+                    ok ->
+                        ok;
+                    already_started ->
+                        ok;
+                    ignored ->
+                        ok;
+                    {error, Reason} ->
+                        erlang:error({failed_to_add_cron_job, CronJob, Reason})
+                end
             end, Crontab);
         undefined ->
             ok

--- a/src/ecrn_cron_sup.erl
+++ b/src/ecrn_cron_sup.erl
@@ -38,28 +38,23 @@ add_job(JobRef, Job) ->
 %% @doc
 %% Add a cron job to be supervised
 -spec add_job(erlcron:job_ref(), erlcron:job(), erlcron:cron_opts()) ->
-    erlcron:job_ref().
+    erlcron:job_ref() | ignored | already_started | {error, term()}.
 add_job(JobRef, Job = {_, _Task}, CronOpts) when is_map(CronOpts) ->
-    add_job2(JobRef, Job, CronOpts);
+    add_job2(JobRef, Job, check_opts(JobRef, CronOpts));
 add_job(JobRef, {When, Task, JobOpts}, CronOpts) when is_map(JobOpts) ->
-    add_job2(JobRef, {When, Task}, maps:merge(CronOpts, JobOpts)).
+    add_job2(JobRef, {When, Task}, check_opts(JobRef, maps:merge(CronOpts, JobOpts))).
 
-add_job2(JobRef, Job = {_, Task}, Opts)
-    when is_function(Task, 2)
-       ; is_function(Task, 0)
-       ; is_tuple(Task), tuple_size(Task)==3
-         , is_atom(element(1,Task))
-         , is_atom(element(2,Task))
-         , is_list(element(3,Task)) ->
+add_job2(JobRef, Job = {_, Task}, Opts) ->
     case check_host(Opts) of
         true ->
-            case supervisor:start_child(?SERVER, [JobRef, Job]) of
+            check_task(JobRef, Task),
+            case supervisor:start_child(?SERVER, [JobRef, Job, Opts]) of
                 {ok, _}                       -> JobRef;
-                {error, {already_started, _}} -> {error, already_started};
+                {error, {already_started, _}} -> already_started;
                 Other                         -> Other
             end;
         false ->
-            false
+            ignored
     end.
 
 %% @doc
@@ -97,6 +92,19 @@ init([]) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+check_opts(JobRef, Map) ->
+    maps:foreach(fun
+        (hostnames, L) when is_list(L) ->
+            ok;
+        (on_job_start, MF) when tuple_size(MF)==2; is_function(MF, 1) ->
+            ok;
+        (on_job_end, MF) when tuple_size(MF)==2; is_function(MF, 2) ->
+            ok;
+        (K, V) ->
+            erlang:error({invalid_option_value, JobRef, {K, V}})
+    end, Map),
+    Map.
+
 check_host(Opts) ->
     case maps:find(hostnames, Opts) of
         {ok, Hosts} when is_list(Hosts) ->
@@ -105,6 +113,50 @@ check_host(Opts) ->
         error ->
             true
     end.
+
+check_task(JobRef, Task) when is_tuple(Task), (tuple_size(Task)==2 orelse tuple_size(Task)==3) ->
+    M = element(1, Task),
+    case code:ensure_loaded(M) of
+        {module, M} ->
+            ok;
+        {error, Err1} ->
+            erlang:error({module_not_loaded, JobRef, Task, Err1})
+    end,
+    check_exists(JobRef, Task);
+check_task(_, Task) when is_function(Task, 0) ->
+    ok;
+check_task(_, Task) when is_function(Task, 2) ->
+    ok;
+check_task(JobRef, Task) ->
+    erlang:error({invalid_job_task, JobRef, Task}).
+
+check_exists(JobRef, {M,F}) ->
+    check_exists2(JobRef, {M,F,undefined});
+check_exists(JobRef, {_,_,A} = MFA) when is_list(A) ->
+    check_exists2(JobRef, MFA).
+
+check_exists2(JobRef, {M,F,A} = Task) ->
+    case erlang:module_loaded(M) of
+        false ->
+            case code:ensure_loaded(M) of
+                {module, M} ->
+                    ok;
+                {error, Err1} ->
+                    erlang:error({module_not_loaded, JobRef, Task, Err1})
+            end;
+        true ->
+            ok
+    end,
+    case A of
+        undefined ->
+            check_arity(JobRef, M, F, [0,2]);
+        _ when is_list(A) ->
+            check_arity(JobRef, M, F, [length(A)])
+    end.
+
+check_arity(JobRef, M, F, Lengths) ->
+    lists:any(fun(Arity) -> erlang:function_exported(M,F,Arity) end, Lengths)
+        orelse erlang:error({wrong_arity_of_job_task, JobRef, {M,F,Lengths}}).
 
 to_list(H) when is_binary(H) -> binary_to_list(H);
 to_list(H) when is_list(H)   -> H.

--- a/src/ecrn_cron_sup.erl
+++ b/src/ecrn_cron_sup.erl
@@ -12,6 +12,7 @@
 %% API
 -export([start_link/0,
          add_job/2,
+         add_job/3,
          all_jobs/0,
          terminate/1]).
 
@@ -28,20 +29,37 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
+%% @doc
+%% Add a cron job to be supervised
+-spec add_job(erlcron:job_ref(), erlcron:job()) -> erlcron:job_ref().
+add_job(JobRef, Job) ->
+    add_job(JobRef, Job, #{}).
 
 %% @doc
-%% Add a chron job to be supervised
--spec add_job(erlcron:job_ref(), erlcron:job()) -> erlcron:job_ref().
-add_job(JobRef, Job = {_, Task}) when is_function(Task, 2)
-                                    ; is_function(Task, 0)
-                                    ; is_tuple(Task), tuple_size(Task)==3
-                                      , is_atom(element(1,Task))
-                                      , is_atom(element(2,Task))
-                                      , is_list(element(3,Task)) ->
-    case supervisor:start_child(?SERVER, [JobRef, Job]) of
-        {ok, _}                       -> JobRef;
-        {error, {already_started, _}} -> {error, already_started};
-        Other                         -> Other
+%% Add a cron job to be supervised
+-spec add_job(erlcron:job_ref(), erlcron:job(), erlcron:cron_opts()) ->
+    erlcron:job_ref().
+add_job(JobRef, Job = {_, _Task}, CronOpts) when is_map(CronOpts) ->
+    add_job2(JobRef, Job, CronOpts);
+add_job(JobRef, {When, Task, JobOpts}, CronOpts) when is_map(JobOpts) ->
+    add_job2(JobRef, {When, Task}, maps:merge(CronOpts, JobOpts)).
+
+add_job2(JobRef, Job = {_, Task}, Opts)
+    when is_function(Task, 2)
+       ; is_function(Task, 0)
+       ; is_tuple(Task), tuple_size(Task)==3
+         , is_atom(element(1,Task))
+         , is_atom(element(2,Task))
+         , is_list(element(3,Task)) ->
+    case check_host(Opts) of
+        true ->
+            case supervisor:start_child(?SERVER, [JobRef, Job]) of
+                {ok, _}                       -> JobRef;
+                {error, {already_started, _}} -> {error, already_started};
+                Other                         -> Other
+            end;
+        false ->
+            false
     end.
 
 %% @doc
@@ -75,3 +93,18 @@ init([]) ->
                  modules  => [ecrn_agent]},
 
     {ok, {SupFlags, [AChild]}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+check_host(Opts) ->
+    case maps:find(hostnames, Opts) of
+        {ok, Hosts} when is_list(Hosts) ->
+            {ok, Host} = inet:gethostname(),
+            lists:member(Host, [to_list(H) || H <- Hosts]);
+        error ->
+            true
+    end.
+
+to_list(H) when is_binary(H) -> binary_to_list(H);
+to_list(H) when is_list(H)   -> H.

--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -5,11 +5,11 @@
 -module(erlcron).
 
 -export([validate/1,
-         cron/1,   cron/2,
-         at/2,     at/3,
-         daily/2,  daily/3,
-         weekly/3, weekly/4,
-         monthly/3,monthly/4,
+         cron/1,   cron/2,    cron/3,
+         at/2,     at/3,      at/4,
+         daily/2,  daily/3,   daily/4,
+         weekly/3, weekly/4,  weekly/5,
+         monthly/3,monthly/4, monthly/5,
          cancel/1,
          epoch/0,
          epoch_seconds/0,
@@ -66,13 +66,33 @@
                    | {run_when(), callable(), job_opts()}.
 
 %% should be opaque but dialyzer does not allow it
--type job_ref()   :: reference() | atom().
+-type job_ref()   :: reference() | atom() | binary().
+%% A job reference.
 
--type job_opts()  :: #{hostnames => [binary()|string()]}.
-%% Job options
+-type job_opts()  ::
+    #{hostnames    => [binary()|string()],
+      id           => term(),
+      on_job_start => {Mod::atom(), Fun::atom()}
+                      | fun((JobRef::job_ref()) -> any()),
+      on_job_end   => {Mod::atom(), Fun::atom()}
+                      | fun((JobRef::job_ref(),
+                             Res :: {ok, term()} | {error, {Reason::term(), Stack::list()}})
+                            -> term())
+    }.
+%% Job options:
 %% <dl>
-%% <dt>{hostnames, [Hostname]}</dt>
-%% <dd>List of hostnames where the job is allowed to run</dd>
+%% <dt>hostnames => [Hostname]</dt>
+%%   <dd>List of hostnames where the job is allowed to run</dd>
+%% <dt>id => ID</dt>
+%%   <dd>An identifier of the job passed to `on_job_start' and `on_job_end'
+%%   callbacks. It can be any term.</dd>
+%% <dt>on_job_start => {Mod, Fun} | fun(JobRef, ID) -> any()</dt>
+%%   <dd>`Mod:Fun(Ref::job_ref(), ID::any())' function to call on job start.
+%%   The result is ignored.</dd>
+%% <dt>{on_job_start, {Mod, Fun}} | fun(JobRef, ID, Result) -> term()</dt>
+%%   <dd>`Mod:Fun(Ref::job_ref(), ID::any(), Result)' function to call after
+%%   a job has ended.  `Result' is `{ok, JobResult::term()}' or
+%%   `{error, `{Reason, StackTrace}}' if there is an exception.</dd>
 %% </dl>
 
 -type cron_opts() :: job_opts().
@@ -93,66 +113,101 @@ validate(Spec) ->
 %%  spec. It returns the JobRef that can be used to manipulate the job
 %%  after it is created.
 
--spec cron(job()) -> job_ref().
+-spec cron(job()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 cron(Job) ->
     cron(make_ref(), Job, #{}).
 
--spec cron(job()|job_ref(), job()|cron_opts()) -> job_ref().
+-spec cron(job()|job_ref(), job()|cron_opts()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 cron(Job, DefOpts) when is_map(DefOpts) ->
     cron(make_ref(), Job, DefOpts);
 
-cron(JobRef, Job) when (is_atom(JobRef) orelse is_reference(JobRef))
+cron(JobRef, Job) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_binary(JobRef))
                      , is_tuple(Job) ->
     cron(JobRef, Job, #{}).
 
+%% @doc Schedule a job identified by a `JobRef'.
+%% A job reference can be a reference, atom, or binary. If it is
+%% an atom, a job will be locally registered by that name.
 %% Returns false if the job is not permitted to run on the current host
--spec cron(job_ref(), job(), job_opts()) -> job_ref() | false.
-cron(JobRef, Job, Opts) when (is_atom(JobRef) orelse is_reference(JobRef))
+-spec cron(job_ref(), job(), job_opts()) ->
+        job_ref() | ignored | already_started | {error, term()}.
+cron(JobRef, Job, Opts) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_binary(JobRef))
                            , is_tuple(Job), is_map(Opts) ->
     ecrn_cron_sup:add_job(JobRef, Job, Opts).
 
 %% @doc
-%% Convenience method to specify a job to run once at the given time.
--spec at(cron_time() | seconds(), callable()) -> job_ref().
+%% Convenience method to specify a job to run once at the given time
+%% or after the amount of time specified.
+-spec at(cron_time() | seconds(), callable()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 at(When, Fun) ->
     at(make_ref(), When, Fun).
 
--spec at(job_ref(), cron_time() | seconds(), function()) -> job_ref().
+-spec at(job_ref(), cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 at(JobRef, When, Fun) ->
     cron(JobRef, {{once, When}, Fun}).
+
+-spec at(job_ref(), cron_time() | seconds(), function(), job_opts()) ->
+        job_ref() | ignored | already_started | {error, term()}.
+at(JobRef, When, Fun, #{} = Opts) ->
+    cron(JobRef, {{once, When}, Fun}, Opts).
 
 %% @doc
 %% Convenience method to specify a job run to run on a daily basis
 %% at a specific time.
--spec daily(cron_time() | seconds(), function()) ->  job_ref().
+-spec daily(cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 daily(When, Fun) ->
     daily(make_ref(), When, Fun).
 
--spec daily(job_ref(), cron_time() | seconds(), function()) ->  job_ref().
+-spec daily(job_ref(), cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 daily(JobRef, When, Fun) ->
     cron(JobRef, {{daily, When}, Fun}).
 
+-spec daily(job_ref(), cron_time() | seconds(), function(), job_opts()) ->
+        job_ref() | ignored | already_started | {error, term()}.
+daily(JobRef, When, Fun, #{} = Opts) ->
+    cron(JobRef, {{daily, When}, Fun}, Opts).
+
 %% @doc
 %% Convenience method to specify a job run to run on a weekly basis
 %% at a specific time.
--spec weekly(dow(), cron_time() | seconds(), function()) ->  job_ref().
+-spec weekly(dow(), cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 weekly(DOW, When, Fun) ->
     weekly(make_ref(), DOW, When, Fun).
 
--spec weekly(job_ref(), dow(), cron_time() | seconds(), function()) -> job_ref().
+-spec weekly(job_ref(), dow(), cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 weekly(JobRef, DOW, When, Fun) ->
     cron(JobRef, {{weekly, DOW, When}, Fun}).
+
+-spec weekly(job_ref(), dow(), cron_time() | seconds(), function(), job_opts()) ->
+        job_ref() | ignored | already_started | {error, term()}.
+weekly(JobRef, DOW, When, Fun, #{} = Opts) ->
+    cron(JobRef, {{weekly, DOW, When}, Fun}, Opts).
 
 %% @doc
 %% Convenience method to specify a job run to run on a weekly basis
 %% at a specific time.
--spec monthly(dom(), cron_time() | seconds(), function()) -> job_ref().
+-spec monthly(dom(), cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 monthly(DOM, When, Fun) ->
     monthly(make_ref(), DOM, When, Fun).
 
--spec monthly(job_ref(), dom(), cron_time() | seconds(), function()) -> job_ref().
+-spec monthly(job_ref(), dom(), cron_time() | seconds(), function()) ->
+        job_ref() | ignored | already_started | {error, term()}.
 monthly(JobRef, DOM, When, Fun) ->
     cron(JobRef, {{monthly, DOM, When}, Fun}).
+
+-spec monthly(job_ref(), dom(), cron_time() | seconds(), function(), job_opts()) ->
+        job_ref() | ignored | already_started | {error, term()}.
+monthly(JobRef, DOM, When, Fun, #{} = Opts) ->
+    cron(JobRef, {{monthly, DOM, When}, Fun}, Opts).
 
 %% @doc
 %% Cancel the job specified by the jobref.

--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -24,6 +24,10 @@
 
 -export_type([job/0,
               job_ref/0,
+              job_opts/0,
+              cron_opts/0,
+              job_start/0,
+              job_end/0,
               run_when/0,
               callable/0,
               dow/0,
@@ -69,15 +73,21 @@
 -type job_ref()   :: reference() | atom() | binary().
 %% A job reference.
 
+-type job_start() :: fun((JobRef::job_ref()) -> ignore | any()).
+%% A function to be called before a job is started. If it returns the `ignore'
+%% atom, the job function will not be executed.
+
+-type job_end()   :: fun((JobRef::job_ref(),
+                         Res :: {ok, term()} | {error, {Reason::term(), Stack::list()}})
+                       -> term()).
+%% A function to be called after a job ended. The function is passed the
+%% job's result.
+
 -type job_opts()  ::
     #{hostnames    => [binary()|string()],
       id           => term(),
-      on_job_start => {Mod::atom(), Fun::atom()}
-                      | fun((JobRef::job_ref()) -> any()),
-      on_job_end   => {Mod::atom(), Fun::atom()}
-                      | fun((JobRef::job_ref(),
-                             Res :: {ok, term()} | {error, {Reason::term(), Stack::list()}})
-                            -> term())
+      on_job_start => {Mod::atom(), Fun::atom()} | job_start(),
+      on_job_end   => {Mod::atom(), Fun::atom()} | job_end()
     }.
 %% Job options:
 %% <dl>

--- a/test/ecrn_test.erl
+++ b/test/ecrn_test.erl
@@ -26,6 +26,7 @@ cron_test_() ->
      end,
      [{timeout, 30, [
        ?FuncTest(set_alarm),
+       ?FuncTest(start_stop_funs),
        ?FuncTest(travel_back_in_time),
        ?FuncTest(cancel_alarm),
        ?FuncTest(big_time_jump),
@@ -72,12 +73,33 @@ cancel_alarm() ->
 
     Self = self(),
 
-    Ref = erlcron:at(AlarmTimeOfDay, fun(_, _) ->
-                                               Self ! ack
-                                     end),
+    Ref = erlcron:at(AlarmTimeOfDay, fun(_, _) -> Self ! ack end),
     erlcron:cancel(Ref),
     erlcron:set_datetime({Day, AlarmTimeOfDay}),
     ?assertMatch(0, collect(ack, 125, 1)).
+
+start_stop_funs() ->
+    Day = {2000,1,1},
+    erlcron:set_datetime({Day,{8,0,0}}),
+    AlarmTimeOfDay = {8,0,1},
+
+    Self = self(),
+    Opts = #{on_job_start => fun(Ref)      -> Self ! {start,  Ref} end,
+             on_job_end   => fun(Ref, Res) -> Self ! {finish, Ref, Res} end},
+    Ref1 = erlcron:at(test1, AlarmTimeOfDay, fun(_, _) -> Self ! ack, 1234 end, Opts),
+    ?assertEqual(test1, Ref1),
+    ?assertMatch(1, collect({start, test1}, 1500, 1)),
+    ?assertMatch(1, collect(ack, 125, 1)),
+    ?assertMatch(1, collect({finish, test1, {ok, 1234}}, 1500, 1)),
+
+    erlcron:set_datetime({Day,{8,0,0}}),
+    Len  = length(lists:seq(1, rand:uniform(10)+2)),
+    Ref2 = erlcron:at(test2, AlarmTimeOfDay, fun(_, _) -> 1 = Len end, Opts),
+
+    ?assertEqual(test2, Ref2),
+    ?assertMatch(1, collect({start, test2}, 1500, 1)),
+    ?assertMatch(0, collect(1, 125, 1)),
+    ?assertMatch({finish, test2, {error,{{badmatch, _}, [_|_]}}}, receive _M -> _M after 1500 -> timeout end).
 
 %% Time jumps ahead one day so we should see the alarms from both days.
 big_time_jump() ->
@@ -107,22 +129,46 @@ travel_back_in_time() ->
     ?assertMatch(true, ExpectedSeconds =< calendar:datetime_to_gregorian_seconds(Past)),
     ?assertMatch(true, ExpectedSeconds < Seconds).
 
-%% Time jumps ahead one day so we should see the alarms from both days.
 cron() ->
     Day1 = {2000,1,1},
-    AlarmTimeOfDay = {15,29,58},
+    AlarmTimeOfDay = {15,29,59},
     erlcron:set_datetime({Day1, AlarmTimeOfDay}),
 
     Self = self(),
 
-    Job = {{daily, {3, 30, pm}},
-            fun(_, _) ->
-                    Self ! ack
-            end},
+    Ref1 = make_ref(),
+    Job1 = {{daily, {3, 30, pm}}, fun(Ref, _) -> Self ! {ack, Ref} end},
+    Ref1 = erlcron:cron(Ref1, Job1),
 
-    erlcron:cron(Job),
+    Job2  = {{daily, {3, 30, pm}}, fun(Ref, _) -> Self ! {ack, Ref} end},
+    test2 = erlcron:cron(test2, Job2),
 
-    ?assertMatch(1, collect(ack, 2500, 1)).
+    Job3  = {{daily, {3, 30, pm}}, fun() -> Self ! {ack, test3} end},
+    test3 = erlcron:cron(test3, Job3),
+
+    Job4 = {{daily, {3, 30, pm}}, {?MODULE, sample_arity0},
+              #{on_job_end => fun(Ref, {ok, undefined}) -> Self ! {ack, Ref} end}},
+    test4 = erlcron:cron(test4, Job4),
+
+    Job5 = {{daily, {3, 30, pm}}, {?MODULE, sample_arity2},
+              #{on_job_end => fun(_Ref, {ok, Res}) -> Self ! Res end}},
+    test5 = erlcron:cron(test5, Job5),
+    Job6 = {{daily, {3, 30, pm}}, {?MODULE, sample_arityN, [test6, Self]}},
+    test6 = erlcron:cron(test6, Job6),
+
+    ?assertMatch(1, collect({ack, Ref1},  1000, 1)),
+    ?assertMatch(1, collect({ack, test2}, 1000, 1)),
+    ?assertMatch(1, collect({ack, test3}, 1000, 1)),
+    ?assertMatch(1, collect({ack, test4}, 1000, 1)),
+    ?assertMatch(1, collect({ack, test5}, 1000, 1)),
+    ?assertMatch(1, collect({ack, test6}, 1000, 1)).
+
+sample_arity0() ->
+    undefined.
+sample_arity2(Ref, _) ->
+    {ack, Ref}.
+sample_arityN(Ref, Pid) ->
+    Pid ! {ack, Ref}.
 
 %% Run job on this host
 cron_run_job_on_host() ->
@@ -141,7 +187,7 @@ cron_skip_job_on_host() ->
     Self = self(),
     Ref  = make_ref(),
     Job  = {{once, {1, 00, pm}}, fun(_,_) -> Self ! Ref end, #{hostnames => [Host ++ "123"]}},
-    ?assertEqual(false, erlcron:cron(Job)).
+    ?assertEqual(ignored, erlcron:cron(Job)).
 
 validation() ->
     erlcron:set_datetime({{2000,1,1}, {15,0,0}}),


### PR DESCRIPTION
- Fix one failing test that didn't adjust local time to univeral time.
- Add job option to restrict a job to be run on specific hosts. This is convenient when the same configuration is given to multiple nodes, and the erl_cron jobs can only be executed on given hostname(s).
- Add job callback options `on_job_start` and `on_job_end` that get called before the job is started and after a job is finished.  These may be useful for logging and other purposes.
- Add `defaults` default options to be specified in the config file.