### PR TITLE
Add automatic publishing of tags to hex (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23, 24, 25]
+        otp: [24, 25]
       fail-fast: false
     container:
       image: erlang:${{ matrix.otp }}

--- a/.github/workflows/hex.yml
+++ b/.github/workflows/hex.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v3
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.github/workflows/hex.yml
+++ b/.github/workflows/hex.yml
@@ -6,11 +6,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@v2
+    container:
+      image: erlang:25.2
 
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref_name }}
       - name: Publish to Hex.pm
-        uses: erlangpack/github-action@v3
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run:  rebar3 hex publish -r hexpm --yes --replace

--- a/.github/workflows/hex.yml
+++ b/.github/workflows/hex.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - '*'
+      - '*.*.*'
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ deps/*
 _build
 rebar3
 TEST*.xml
+.deps_plt
+.eunit/
+.rebar/


### PR DESCRIPTION
In order to have this functionality working, whoever has access to the hex.pm site for this organization, please:

1. Create a key on the [Hex.pm dashboard](https://hex.pm/dashboard/keys).
2. Add the key from step 1 to this GitHub repository’s secrets. Call it HEX_API_KEY.
