### PR TITLE
Fix cronjob startup config (issue #71)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ dialyzer: $(DEPS_PLT)
 	$(REBAR) $@
 
 typer:
-	typer --plt $(DEPS_PLT) -r ./src
+	typer --plt $(DEPS_PLT) -I include -r ./src
 
 shell: get-deps compile
 # You often want *rebuilt* rebar tests to be available to the

--- a/README.md
+++ b/README.md
@@ -163,7 +163,18 @@ The app.config file can be as follow:
                 #{hostnames => ["somehost"]},
 
             {{daily, {every, {23, sec}, {between, {3, pm}, {3, 30, pm}}}},
-             {io, fwrite, ["Hello, world!~n"]}}
+             {io, fwrite, ["Hello, world!~n"]}},
+
+            %% A job spec can be defined as a map, where the `interval' and
+            %% `execute' keys are mandatory:
+            #{id => test_job,    interval  => {daily, {1, 0, pm}},
+                                 execute   => {io, fwrite, ["Hello, world!~n"]}},
+
+            %% If defined as a map, the map can contain any `erlcron:job_opts()'
+            %% options:
+            #{id => another_job, interval  => {daily, {1, 0, pm}},
+                                 execute   => {io, fwrite, ["Hello, world!~n"]},
+                                 hostnames => ["myhost"]}
         ]},
 
         %% Instead of specifying individual options for each job, you can

--- a/include/erlcron.hrl
+++ b/include/erlcron.hrl
@@ -1,0 +1,12 @@
+%% compatibility
+-ifdef(OTP_RELEASE). %% this implies 21 or higher
+-define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
+-define(GET_STACK(Stacktrace), Stacktrace).
+-include_lib("kernel/include/logger.hrl").
+-else.
+-define(EXCEPTION(Class, Reason, _), Class:Reason).
+-define(GET_STACK(_),        erlang:get_stacktrace()).
+-define(LOG_ERROR(Report),   error_logger:error_report(Report)).
+-define(LOG_WARNING(Report), error_logger:warning_report(Report)).
+-define(LOG_INFO(Report),    error_logger:info_report(Report)).
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -9,12 +9,10 @@
 
 %% rebar3_git_vsn plugin:
 {provider_hooks, [{post, [{compile, git_vsn}]}]}.
-{git_vsn, [{vsn_type, gitver}, {env_key, ignore}]}.
+{git_vsn, [{vsn_format, gitver}, {env_key, ignore}]}.
 
 %% Compiler Options ============================================================
-{erl_opts,
- [debug_info,
-  warnings_as_errors]}.
+{erl_opts, [debug_info, warnings_as_errors]}.
 
 %% EUnit =======================================================================
 {eunit_opts, [%verbose,

--- a/rebar.config
+++ b/rebar.config
@@ -3,11 +3,13 @@
 {deps, []}.
 
 %% Rebar Plugins ===============================================================
-{plugins, [{rebar3_git_vsn, {git, "https://github.com/saleyn/rebar3_git_vsn.git"}}]}.
+{plugins, [{rebar3_git_vsn,
+              {git, "https://github.com/saleyn/rebar3_git_vsn.git",
+              {branch, "master"}}}]}.
 
 %% rebar3_git_vsn plugin:
 {provider_hooks, [{post, [{compile, git_vsn}]}]}.
-{git_vsn, [{vsn_type, gitver}]}.
+{git_vsn, [{vsn_type, gitver}, {env_key, ignore}]}.
 
 %% Compiler Options ============================================================
 {erl_opts,

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,11 @@
 {deps, []}.
 
 %% Rebar Plugins ===============================================================
-{plugins, []}.
+{plugins, [{rebar3_git_vsn, {git, "https://github.com/saleyn/rebar3_git_vsn.git"}}]}.
+
+%% rebar3_git_vsn plugin:
+{provider_hooks, [{post, [{compile, git_vsn}]}]}.
+{git_vsn, [{vsn_type, gitver}]}.
 
 %% Compiler Options ============================================================
 {erl_opts,

--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,9 @@
   warnings_as_errors]}.
 
 %% EUnit =======================================================================
-{eunit_opts, [verbose,
-              {report, {eunit_surefire, [{dir, "."}]}}]}.
+{eunit_opts, [%verbose,
+              %{report, {eunit_surefire, [{dir, "."}]}}]}.
+             no_tty]}.
 
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/ecrn_agent.erl
+++ b/src/ecrn_agent.erl
@@ -45,17 +45,7 @@
 -define(MAX_TIMEOUT_MSEC,  1800000).
 -define(SEC_IN_A_DAY,      86400).
 
-%% compatibility
--ifdef(OTP_RELEASE). %% this implies 21 or higher
--define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
--define(GET_STACK(Stacktrace), Stacktrace).
--include_lib("kernel/include/logger.hrl").
--else.
--define(EXCEPTION(Class, Reason, _), Class:Reason).
--define(GET_STACK(_), erlang:get_stacktrace()).
--define(LOG_ERROR(Report),   error_logger:error_report(Report)).
--define(LOG_WARNING(Report), error_logger:warning_report(Report)).
--endif.
+-include("erlcron.hrl").
 
 %%%===================================================================
 %%% Types

--- a/src/ecrn_app.erl
+++ b/src/ecrn_app.erl
@@ -61,8 +61,9 @@ setup(Def) ->
     case application:get_env(erlcron, crontab) of
         {ok, Crontab} ->
             lists:foreach(fun(CronJob) ->
-                Res = erlcron:cron(CronJob, Def),
-                ?LOG_INFO("CRON: adding job ~1024p: ~p", [CronJob, Res]),
+                Res  = erlcron:cron(CronJob, Def),
+                Res2 = if is_reference(Res) -> io_lib:format(": ~p", [Res]); true -> [] end,
+                ?LOG_INFO("CRON: adding job ~1024p~s", [CronJob, Res2]),
                 case Res of
                     already_started ->
                         erlang:error({duplicate_job_reference, CronJob});

--- a/src/ecrn_app.erl
+++ b/src/ecrn_app.erl
@@ -58,11 +58,11 @@ setup() ->
               erlang:error("erlcron/defaults config must be a map!"),
             lists:foreach(fun(CronJob) ->
                 case erlcron:cron(CronJob, Def) of
-                    ok ->
-                        ok;
                     already_started ->
-                        ok;
+                        erlang:error({duplicate_job_reference, CronJob});
                     ignored ->
+                        ok;
+                    Ref when is_reference(Ref); is_atom(Ref); is_binary(Ref) ->
                         ok;
                     {error, Reason} ->
                         erlang:error({failed_to_add_cron_job, CronJob, Reason})

--- a/src/ecrn_app.erl
+++ b/src/ecrn_app.erl
@@ -15,6 +15,8 @@
 %% Application callbacks
 -export([start/2, stop/1]).
 
+-include("erlcron.hrl").
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -40,7 +42,12 @@ manual_stop() ->
 start(_StartType, _StartArgs) ->
     case ecrn_sup:start_link() of
         {ok, Pid} ->
-            setup(),
+            {ok, H} = inet:gethostname(),
+            Def = application:get_env(erlcron, defaults, #{}),
+            is_map(Def) orelse
+              erlang:error("erlcron/defaults config must be a map!"),
+            ?LOG_INFO("CRON: started on host ~p using defaults: ~1024p", [H, Def]),
+            setup(Def),
             {ok, Pid};
         Error ->
             Error
@@ -50,14 +57,13 @@ start(_StartType, _StartArgs) ->
 stop(_State) ->
     ok.
 
-setup() ->
+setup(Def) ->
     case application:get_env(erlcron, crontab) of
         {ok, Crontab} ->
-            Def = application:get_env(erlcron, defaults, #{}),
-            is_map(Def) orelse
-              erlang:error("erlcron/defaults config must be a map!"),
             lists:foreach(fun(CronJob) ->
-                case erlcron:cron(CronJob, Def) of
+                Res = erlcron:cron(CronJob, Def),
+                ?LOG_INFO("CRON: adding job ~1024p: ~p", [CronJob, Res]),
+                case Res of
                     already_started ->
                         erlang:error({duplicate_job_reference, CronJob});
                     ignored ->

--- a/src/ecrn_cron_sup.erl
+++ b/src/ecrn_cron_sup.erl
@@ -171,6 +171,8 @@ check_exists2(JobRef, {M,F,A} = Task) ->
     end.
 
 check_arity(JobRef, M, F, Lengths) ->
+    {module, M} == code:ensure_loaded(M)
+        orelse erlang:error({job_task_module_not_loaded, JobRef, M}),
     lists:any(fun(Arity) -> erlang:function_exported(M,F,Arity) end, Lengths)
         orelse erlang:error({wrong_arity_of_job_task, JobRef, {M,F,Lengths}}).
 

--- a/src/ecrn_cron_sup.erl
+++ b/src/ecrn_cron_sup.erl
@@ -100,6 +100,8 @@ check_opts(JobRef, Map) ->
             ok;
         (on_job_end, MF) when tuple_size(MF)==2; is_function(MF, 2) ->
             ok;
+        (id, ID) when is_atom(ID); is_binary(ID); is_reference(ID) ->
+            ok;
         (K, V) ->
             erlang:error({invalid_option_value, JobRef, {K, V}})
     end, Map),

--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -59,7 +59,7 @@
 -type dow()        :: dow_day() | [dow_day()].
 -type callable()   :: {M :: module(), F :: atom(), A :: [term()]} |
                       fun(() -> term()) |
-                      fun((JobRef::atom()|reference(), calendar:datetime()) -> term()).
+                      fun((JobRef::job_ref(), calendar:datetime()) -> term()).
 -type run_when()   :: {once, cron_time()}
                     | {once, seconds()}
                     | {daily, period()}
@@ -126,12 +126,12 @@ validate(Spec) ->
 -spec cron(job()) ->
         job_ref() | ignored | already_started | {error, term()}.
 cron(Job) ->
-    cron(make_ref(), Job, #{}).
+    cron(make_ref(Job), Job, #{}).
 
 -spec cron(job()|job_ref(), job()|cron_opts()) ->
         job_ref() | ignored | already_started | {error, term()}.
 cron(Job, DefOpts) when is_map(DefOpts) ->
-    cron(make_ref(), Job, DefOpts);
+    cron(make_ref(Job), Job, DefOpts);
 
 cron(JobRef, Job) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_binary(JobRef))
                      , is_tuple(Job) ->
@@ -291,3 +291,10 @@ multi_set_datetime({D,T} = DateTime) when tuple_size(D)==3, tuple_size(T)==3 ->
     BadNodes :: [node()].
 multi_set_datetime(Nodes, DateTime) when is_list(Nodes), tuple_size(DateTime)==2 ->
     ecrn_control:multi_set_datetime(Nodes, DateTime).
+
+make_ref({_When, _Callable, #{id := ID}}) when is_atom(ID); is_binary(ID); is_reference(ID) ->
+    ID;
+make_ref({_When, _Callable, #{}}) ->
+    make_ref();
+make_ref({_When, _Callable}) ->
+    make_ref().

--- a/src/erlcron.erl
+++ b/src/erlcron.erl
@@ -67,7 +67,8 @@
                     | {monthly, dom()|[dom()], period()}.
 
 -type  job()      :: {run_when(), callable()}
-                   | {run_when(), callable(), job_opts()}.
+                   | {run_when(), callable(), job_opts()}
+                   | #{id => job_ref(), interval => run_when(), execute => callable(), _ => any()}.
 
 %% should be opaque but dialyzer does not allow it
 -type job_ref()   :: reference() | atom() | binary().
@@ -133,8 +134,7 @@ cron(Job) ->
 cron(Job, DefOpts) when is_map(DefOpts) ->
     cron(make_ref(Job), Job, DefOpts);
 
-cron(JobRef, Job) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_binary(JobRef))
-                     , is_tuple(Job) ->
+cron(JobRef, Job) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_binary(JobRef)) ->
     cron(JobRef, Job, #{}).
 
 %% @doc Schedule a job identified by a `JobRef'.
@@ -144,7 +144,7 @@ cron(JobRef, Job) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_bi
 -spec cron(job_ref(), job(), job_opts()) ->
         job_ref() | ignored | already_started | {error, term()}.
 cron(JobRef, Job, Opts) when (is_atom(JobRef) orelse is_reference(JobRef) orelse is_binary(JobRef))
-                           , is_tuple(Job), is_map(Opts) ->
+                           , is_map(Opts) ->
     ecrn_cron_sup:add_job(JobRef, Job, Opts).
 
 %% @doc
@@ -292,6 +292,8 @@ multi_set_datetime({D,T} = DateTime) when tuple_size(D)==3, tuple_size(T)==3 ->
 multi_set_datetime(Nodes, DateTime) when is_list(Nodes), tuple_size(DateTime)==2 ->
     ecrn_control:multi_set_datetime(Nodes, DateTime).
 
+make_ref(#{id := ID}) when is_atom(ID); is_binary(ID); is_reference(ID) ->
+    ID;
 make_ref({_When, _Callable, #{id := ID}}) when is_atom(ID); is_binary(ID); is_reference(ID) ->
     ID;
 make_ref({_When, _Callable, #{}}) ->

--- a/test/ecrn_startup_test.erl
+++ b/test/ecrn_startup_test.erl
@@ -1,4 +1,5 @@
 %%% @copyright Erlware, LLC. All Rights Reserved.
+%%% vim:ts=4:ts=4:et
 %%%
 %%% This file is provided to you under the BSD License; you may not use
 %%% this file except in compliance with the License.
@@ -9,6 +10,12 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(FuncTest(A), {atom_to_list(A), fun A/0}).
+
+disable_sasl_logger() ->
+    logger:add_handler_filter(default, ?MODULE, {fun(_,_) -> stop end, nostate}).
+
+enable_sasl_logger() ->
+    logger:remove_handler_filter(default, ?MODULE).
 
 %%%===================================================================
 %%% Types
@@ -26,11 +33,13 @@ cron_test_() ->
             {{daily, {3, 0, pm}}, fun(_JobRef, _Now) -> erlang:system_time() end, #{id => Ref}},
             #{id => four, interval => {daily, {1, 0, pm}}, execute => {erlang, system_time, []}}
         ]),
+        disable_sasl_logger(),
         application:start(erlcron),
         Ref
      end,
      fun(_) ->
-        application:stop(erlcron)
+        application:stop(erlcron),
+        enable_sasl_logger()
      end,
      {with, [fun(Ref) -> check_startup_jobs(Ref) end]}
     }.
@@ -42,3 +51,68 @@ check_startup_jobs(Ref) ->
     ?assert(is_pid(ecrn_reg:get(<<"two">>))),
     ?assert(is_pid(ecrn_reg:get(Ref))),
     ?assert(is_pid(ecrn_reg:get(four))).
+
+cron_bad_job_spec_test_() ->
+    {setup,
+     fun() ->
+         application:set_env(sasl, sasl_error_logger, false),
+         application:load(erlcron),
+         application:set_env(erlcron, sup_intensity, 0),
+         application:set_env(erlcron, sup_period,    1),
+         disable_sasl_logger()
+     end,
+     fun(_) ->
+         enable_sasl_logger()
+     end,
+     [
+         ?_assertMatch(
+             {error,
+                 {bad_return, {{ecrn_app,start,[normal,[]]},
+                     {'EXIT', {{module_not_loaded,one, {'$$$bad_module',system_time,[]}, nofile}, [_|_]}}}}},
+             begin
+                 application:set_env(erlcron, crontab, [
+                     {{daily, {1, 0, pm}}, {'$$$bad_module', system_time, []}, #{id => one}}
+                 ]),
+                 application:start(erlcron)
+             end),
+         ?_assertMatch(
+            {error,
+                {bad_return,
+                    {{ecrn_app,start,[normal,[]]},
+                     {'EXIT',
+                         {{wrong_arity_of_job_task, one, "erlang:system_time1000/0"},
+                          [_|_]}}}}},
+             begin
+                 application:set_env(erlcron, crontab, [
+                     {{daily, {1, 0, pm}}, {erlang, system_time1000, []}, #{id => one}}
+                 ]),
+                 application:start(erlcron)
+             end),
+         ?_assertMatch(
+            {error,
+                {bad_return,
+                    {{ecrn_app,start,[normal,[]]},
+                     {'EXIT',
+                         {{wrong_arity_of_job_task, one, "erlang:system_time/3"},
+                          [_|_]}}}}},
+             begin
+                 application:set_env(erlcron, crontab, [
+                     {{daily, {1, 0, pm}}, {erlang, system_time, [1,2,3]}, #{id => one}}
+                 ]),
+                 application:start(erlcron)
+             end),
+         ?_assertMatch(
+            {error,
+                {bad_return,
+                    {{ecrn_app,start,[normal,[]]},
+                     {'EXIT',
+                         {{wrong_arity_of_job_task, one, "erlang:system_time123/[0,2]"},
+                          [_|_]}}}}},
+             begin
+                 application:set_env(erlcron, crontab, [
+                     {{daily, {1, 0, pm}}, {erlang, system_time123}, #{id => one}}
+                 ]),
+                 application:start(erlcron)
+             end)
+     ]
+    }.

--- a/test/ecrn_startup_test.erl
+++ b/test/ecrn_startup_test.erl
@@ -113,6 +113,20 @@ cron_bad_job_spec_test_() ->
                      {{daily, {1, 0, pm}}, {erlang, system_time123}, #{id => one}}
                  ]),
                  application:start(erlcron)
+             end),
+         ?_assertMatch(
+             ignored,
+             erlcron:cron({{daily, {1, 0, pm}}, {'$$$bad_module', system_time, []},
+                           #{id => ignore_host, hostnames => [<<"$$somehost">>]}})
+             ),
+         ?_assertMatch(
+             ok,
+             begin
+                 application:set_env(erlcron, crontab, [
+                     {{daily, {1, 0, pm}}, {'$$$bad_module', system_time, []},
+                      #{id => ignore_host, hostnames => [<<"$$somehost">>]}}
+                 ]),
+                 application:start(erlcron)
              end)
      ]
     }.

--- a/test/ecrn_startup_test.erl
+++ b/test/ecrn_startup_test.erl
@@ -23,7 +23,8 @@ cron_test_() ->
         application:set_env(erlcron, crontab, [
             {{daily, {1, 0, pm}}, {erlang, system_time, []}, #{id => one}},
             {{daily, {2, 0, pm}}, fun() -> erlang:system_time() end, #{id => <<"two">>}},
-            {{daily, {3, 0, pm}}, fun(_JobRef, _Now) -> erlang:system_time() end, #{id => Ref}}
+            {{daily, {3, 0, pm}}, fun(_JobRef, _Now) -> erlang:system_time() end, #{id => Ref}},
+            #{id => four, interval => {daily, {1, 0, pm}}, execute => {erlang, system_time, []}}
         ]),
         application:start(erlcron),
         Ref
@@ -35,8 +36,9 @@ cron_test_() ->
     }.
 
 check_startup_jobs(Ref) ->
-    ?assertMatch([_, _, _], ecrn_cron_sup:all_jobs()),
-    ?assertEqual([one, Ref, <<"two">>], ecrn_reg:get_all_refs()),
+    ?assertMatch([_, _, _, _], ecrn_cron_sup:all_jobs()),
+    ?assertEqual([four, one, Ref, <<"two">>], ecrn_reg:get_all_refs()),
     ?assert(is_pid(ecrn_reg:get(one))),
     ?assert(is_pid(ecrn_reg:get(<<"two">>))),
-    ?assert(is_pid(ecrn_reg:get(Ref))).
+    ?assert(is_pid(ecrn_reg:get(Ref))),
+    ?assert(is_pid(ecrn_reg:get(four))).

--- a/test/ecrn_startup_test.erl
+++ b/test/ecrn_startup_test.erl
@@ -1,0 +1,42 @@
+%%% @copyright Erlware, LLC. All Rights Reserved.
+%%%
+%%% This file is provided to you under the BSD License; you may not use
+%%% this file except in compliance with the License.
+-module(ecrn_startup_test).
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FuncTest(A), {atom_to_list(A), fun A/0}).
+
+%%%===================================================================
+%%% Types
+%%%===================================================================
+cron_test_() ->
+    {setup,
+     fun() ->
+        Ref = make_ref(),
+        application:load(erlcron),
+        application:set_env(erlcron, sup_intensity, 0),
+        application:set_env(erlcron, sup_period,    1),
+        application:set_env(erlcron, crontab, [
+            {{daily, {1, 0, pm}}, {erlang, system_time, []}, #{id => one}},
+            {{daily, {2, 0, pm}}, fun() -> erlang:system_time() end, #{id => <<"two">>}},
+            {{daily, {3, 0, pm}}, fun(_JobRef, _Now) -> erlang:system_time() end, #{id => Ref}}
+        ]),
+        application:start(erlcron),
+        Ref
+     end,
+     fun(_) ->
+        application:stop(erlcron)
+     end,
+     {with, [fun(Ref) -> check_startup_jobs(Ref) end]}
+    }.
+
+check_startup_jobs(Ref) ->
+    ?assertMatch([_, _, _], ecrn_cron_sup:all_jobs()),
+    ?assertEqual([one, Ref, <<"two">>], ecrn_reg:get_all_refs()),
+    ?assert(is_pid(ecrn_reg:get(one))),
+    ?assert(is_pid(ecrn_reg:get(<<"two">>))),
+    ?assert(is_pid(ecrn_reg:get(Ref))).


### PR DESCRIPTION
- Fix the issue #71
- Add test case for verifying startup configuration
- Implement ability to define jobs using a map `#{interval => Interval, execute => MFA, id => ID, ...}`